### PR TITLE
Corrected 'java -version' command

### DIFF
--- a/examples/helidon-quickstart-se/README.md
+++ b/examples/helidon-quickstart-se/README.md
@@ -13,7 +13,7 @@ This example implements a simple Hello World REST service.
 
 Verify prerequisites
 ```
-java --version
+java -version
 mvn --version
 docker --version
 minikube version


### PR DESCRIPTION
The existing command `java --version` returns an error in JDK 8.

`java -version` works.